### PR TITLE
Add '-XInstanceSigs' extension to stylish

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -230,6 +230,7 @@ language_extensions:
   - FunctionalDependencies
   - GADTs
   - GeneralizedNewtypeDeriving
+  - InstanceSigs
   - LambdaCase
   - MultiParamTypeClasses
   - MultiWayIf


### PR DESCRIPTION
Sometimes it's useful to have this extension for documentation purposes. But `.stylish-haskell` doesn't work without it.