### PR TITLE
[#65] Bump formatting, drop text-format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+0.10.0
+=====
+
+* [#65](https://github.com/serokell/serokell-util/issues/65):
+  More recent version of `formatting` is now supported.
+  `text-format` dependency was dropped, so there are no instances of
+      `Data.Text.Buildable` anymore.
+  Also some deprecated functions have been removed.
+
 0.9.0
 =====
 

--- a/serokell-util.cabal
+++ b/serokell-util.cabal
@@ -58,7 +58,7 @@ library
                      , deepseq
                      , exceptions
                      , fmt
-                     , formatting >= 6.2.0 && < 6.3
+                     , formatting >= 6.3.4 && < 6.4
                      , hashable >= 1.2.4.0
                      , microlens
                      , microlens-mtl
@@ -71,7 +71,6 @@ library
                      , scientific
                      , template-haskell
                      , text
-                     , text-format
                      , th-lift-instances
                      , transformers
                      , universum ^>= 1.1.0
@@ -104,6 +103,7 @@ test-suite serokell-test
   build-depends:       aeson >= 1.0 && < 1.4
                      , base >=4.8
                      , extra >= 1.6
+                     , formatting
                      , hspec >= 2.1.10
                      , QuickCheck >= 2.8.1
                      , quickcheck-instances

--- a/src/Serokell/Data/Variant/Serialization.hs
+++ b/src/Serokell/Data/Variant/Serialization.hs
@@ -10,6 +10,7 @@ module Serokell.Data.Variant.Serialization
 import Universum
 
 import Data.Scientific (floatingOrInteger)
+import Formatting (build, sformat)
 
 import Serokell.Data.Variant.Variant (VarMap, Variant (..))
 import Serokell.Util.Base64 (JsonByteString (JsonByteString))
@@ -32,7 +33,8 @@ import qualified Data.HashMap.Strict as HM
 --    result type depends on sign (negative ⇒ Int, otherwise UInt).
 
 varMapToObject :: VarMap -> Aeson.Object
-varMapToObject = HM.fromList . map (bimap pretty Aeson.toJSON) . toPairs
+varMapToObject =
+    HM.fromList . map (bimap (sformat build) Aeson.toJSON) . toPairs
 
 instance Aeson.ToJSON Variant where
     toJSON VarNone       = Aeson.Null

--- a/src/Serokell/Data/Variant/Variant.hs
+++ b/src/Serokell/Data/Variant/Variant.hs
@@ -12,7 +12,7 @@ module Serokell.Data.Variant.Variant
 
 import Universum
 
-import Data.Text.Buildable (Buildable (build))
+import qualified Formatting.Buildable as B
 import GHC.Exts (IsList (..))
 
 import Serokell.Util.Text (listBuilderJSONIndent, mapBuilder)
@@ -37,14 +37,14 @@ data Variant
     | VarMap !VarMap        -- ^ Map (with unique keys) from Variant to Variant.
     deriving (Show,Eq,Generic)
 
-instance Buildable Variant where
+instance B.Buildable Variant where
     build VarNone       = "None"
-    build (VarBool v)   = build v
-    build (VarInt v)    = build v
-    build (VarUInt v)   = build v
-    build (VarFloat v)  = build v
-    build (VarBytes v)  = build . B16.encode $ v
-    build (VarString v) = build v
+    build (VarBool v)   = B.build v
+    build (VarInt v)    = B.build v
+    build (VarUInt v)   = B.build v
+    build (VarFloat v)  = B.build v
+    build (VarBytes v)  = B.build . B16.encode $ v
+    build (VarString v) = B.build v
     build (VarList v)   = listBuilderJSONIndent 2 v
     build (VarMap v)    = mapBuilder . toPairs $ v
 

--- a/src/Serokell/Util/Bench.hs
+++ b/src/Serokell/Util/Bench.hs
@@ -13,7 +13,7 @@ module Serokell.Util.Bench
        , perSecond
        ) where
 
-import Universum
+import Universum hiding (Buildable)
 
 import Fmt (Buildable (build), (+||), (||+))
 import System.Clock (Clock (..), TimeSpec, diffTimeSpec, getTime, toNanoSecs)

--- a/src/Serokell/Util/Exceptions.hs
+++ b/src/Serokell/Util/Exceptions.hs
@@ -17,10 +17,9 @@ import Universum
 import Formatting (bprint, stext, string, (%))
 
 import qualified Control.Monad as Monad
-import qualified Data.Text.Buildable
-import qualified Data.Text.Format as F
+import qualified Formatting.Buildable
 
-instance Buildable SomeException where
+instance Formatting.Buildable.Buildable SomeException where
     build e =
         case fromException e of
             Nothing                  -> bprint string (displayException e)
@@ -33,8 +32,8 @@ newtype TextException = TextException
 
 instance Exception TextException
 
-instance Buildable TextException where
-    build = F.build "TextException: {}" . F.Only . teMessage
+instance Formatting.Buildable.Buildable TextException where
+    build = bprint ("TextException: " %stext) . teMessage
 
 throwText :: MonadThrow m
           => Text -> m a

--- a/src/Serokell/Util/Text.hs
+++ b/src/Serokell/Util/Text.hs
@@ -35,13 +35,6 @@ module Serokell.Util.Text
        , mapBuilder
        , mapBuilderJson
 
-       -- * @text-format@ utilities
-       , format
-       , format'
-       , formatSingle
-       , formatSingle'
-       , buildSingle
-
        -- * String readers
        , readFractional
        , readDouble
@@ -51,21 +44,21 @@ module Serokell.Util.Text
 
 import Prelude
 
-import Data.Text.Buildable (Buildable (build))
-import Data.Text.Format.Params (Params)
 import Data.Text.Lazy.Builder.RealFloat (FPFormat (Exponent, Fixed, Generic))
+import Formatting (bprint, (%))
 import Formatting (Format, fixed, later, sformat)
+import Formatting.Buildable (Buildable (build))
 import GHC.Exts (IsList (..))
 
 import Serokell.Util.Common (chunksOf)
 
 import qualified Data.Text as T
-import qualified Data.Text.Format as F
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Builder as B
 import qualified Data.Text.Lazy.Builder.Int as B
 import qualified Data.Text.Lazy.Builder.RealFloat as B
 import qualified Data.Text.Read as T
+import qualified Formatting.Formatters as F
 import qualified Universum as U
 
 -- | Render a floating point number using normal notation, with the
@@ -126,13 +119,14 @@ mapJson = later mapBuilderJson
 pairBuilder
     :: (Buildable a, Buildable b)
     => (a, b) -> B.Builder
-pairBuilder = F.build "({}, {})"
+pairBuilder (a, b) = bprint ("(" % F.build % ", " % F.build % ")") a b
 
 -- | Prints triple (a, b, c) like "(a, b, c)"
 tripleBuilder
     :: (Buildable a, Buildable b, Buildable c)
     => (a, b, c) -> B.Builder
-tripleBuilder = F.build "({}, {}, {})"
+tripleBuilder (a, b, c) =
+    bprint ("("%F.build%", "%F.build%", "%F.build%")") a b c
 
 -- | Generic list builder. Prints prefix, then values separated by delimiter and finally suffix
 listBuilder
@@ -202,31 +196,8 @@ mapBuilder = listBuilderJSON . fmap pairBuilder
 mapBuilderJson
     :: (IsList t, Item t ~ (k, v), Buildable k, Buildable v)
     => t -> B.Builder
-mapBuilderJson = _listBuilder "{" ", " "}" . map (F.build "{}: {}") . toList
-
-{-# DEPRECATED format, format', formatSingle, formatSingle' "Not typesafe. Use formatting library instead" #-}
-
--- | Re-export Data.Text.Format.format for convenience
-format :: Params ps
-       => F.Format -> ps -> LT.Text
-format = F.format
-
--- | Version of Data.Text.Format.format which returns strict Text
-format' :: Params ps
-        => F.Format -> ps -> T.Text
-format' f = LT.toStrict . F.format f
-
-formatSingle :: Buildable a
-             => F.Format -> a -> LT.Text
-formatSingle f = format f . F.Only
-
-formatSingle' :: Buildable a
-              => F.Format -> a -> T.Text
-formatSingle' f = LT.toStrict . formatSingle f
-
-buildSingle :: Buildable a
-            => F.Format -> a -> B.Builder
-buildSingle f = F.build f . F.Only
+mapBuilderJson = _listBuilder "{" ", " "}" .
+    map (\(a, b) -> bprint (F.build % ": " % F.build) a b) . toList
 
 -- | Read fractional number. Returns error (i. e. Left) if there is something else
 readFractional :: Fractional a => T.Text -> Either String a

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -8,6 +8,7 @@ extra-deps:
 - aeson-options-0.0.0
 - containers-0.5.10.2
 - fmt-0.5.0.0
+- formatting-6.3.6
 - o-clock-0.1.1
 - recursion-schemes-5
 - universum-1.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,4 @@ nix:
 extra-deps:
 - o-clock-0.1.1
 - universum-1.1.0
+- formatting-6.3.6

--- a/test/Test/Serokell/Data/Variant/VariantSpec.hs
+++ b/test/Test/Serokell/Data/Variant/VariantSpec.hs
@@ -8,6 +8,7 @@ module Test.Serokell.Data.Variant.VariantSpec
 import Universum
 
 import Data.Scientific (floatingOrInteger, fromFloatDigits)
+import Formatting (build, sformat)
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck ((===))
@@ -46,7 +47,7 @@ jsonFixer (S.VarFloat f) =
 jsonFixer v = v
 
 toStr :: S.Variant -> S.Variant
-toStr = S.VarString . pretty
+toStr = S.VarString . sformat build
 
 jsonMid :: S.Variant -> S.Variant
 jsonMid = maybe err id . A.decode . A.encode


### PR DESCRIPTION
Now more recent version of `formatting` is supported.
`text-format` dependency is dropped, because it's not maintained anymore.

Resolves #65.